### PR TITLE
[Docs] Update README.md: noting difference in iOS action

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This action is a swap in replacement for the [Maestro Cloud Action](https://gith
 
 It lets you run your flows on [devicecloud.dev](https://devicecloud.dev) to save money and access extra features.
 
+*Note: There is one key difference from the Maestro version of the action - for iOS uploads, a `.zip` is required, rather than a `.app`*
+
 # Using the action
 
 Add the following to your workflow. Note that you can use the `v1` tag if you want to keep using the latest version of the action, which will automatically resolve to all `v1.minor.patch` versions as they get published.


### PR DESCRIPTION
The difference in required file format, when everything else about the action mimicks the Maestro version so closely, feels like it should be called out, since people moving from the Maestro action will likely be trying to drop in their existing action, and might miss this key difference. 