### PR TITLE
feat: add missing CLI flags to bring GHA to full feature parity

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -78,10 +78,11 @@ inputs:
     description: '[Android only] The orientation of the device to run your flow against in degrees <options: 0|90|180|270>'
     required: false
   quiet:
-    description: 'Quieter console output that wont provide progress updates'
+    description: 'Quieter console output that wont provide progress updates. Defaults to true in CI.'
     required: false
+    default: 'true'
   report:
-    description: 'Runs Maestro with the --format flag, this will generate a report in the specified format <options: junit|html|html-detailed>'
+    description: 'Runs Maestro with the --format flag, this will generate a report in the specified format <options: junit|html|html-detailed|allure>'
     required: false
   retry:
     description: 'Number of times to retry the run if it fails (same as pressing retry in the UI, this is free)'
@@ -116,6 +117,33 @@ inputs:
     description: 'Automatically attach GitHub/PR context (branch, SHA, PR number, PR URL, run ID, repo) to the test run as metadata. Set to "false" to opt out.'
     required: false
     default: 'true'
+  app-url:
+    description: 'Signed URL to an Expo iOS build (.tar.gz). The archive is downloaded and extracted automatically. Expo signed URLs expire after ~1 hour.'
+    required: false
+  show-crosshairs:
+    description: '[Android only] Display crosshairs for screen interactions during test execution'
+    required: false
+  dry-run:
+    description: 'Simulate the run without actually triggering the upload/test, useful for debugging workflow issues'
+    required: false
+  metadata:
+    description: 'One or more key=value metadata pairs to attach to the run (one per line, e.g. MY_KEY=my_value)'
+    required: false
+  json:
+    description: 'Output results in JSON format. Note: will always provide exit code 0'
+    required: false
+  json-file-name:
+    description: 'Custom name for the JSON output file (can include relative path). Requires json-file: true.'
+    required: false
+  allure-path:
+    description: 'Custom file path for downloaded Allure report (requires report: allure, default: ./report.html)'
+    required: false
+  html-path:
+    description: 'Custom file path for downloaded HTML report (requires report: html, default: ./report.html)'
+    required: false
+  artifacts-path:
+    description: 'Custom file path for downloaded artifacts zip (default: ./artifacts.zip)'
+    required: false
 
 outputs:
   DEVICE_CLOUD_CONSOLE_URL:

--- a/dist/index.js
+++ b/dist/index.js
@@ -31602,7 +31602,7 @@ const getLatestDcdVersion = (...args_1) => __awaiter(void 0, [...args_1], void 0
 const run = () => __awaiter(void 0, void 0, void 0, function* () {
     var _a;
     try {
-        const { additionalAppBinaryIds, additionalAppFiles, androidApiLevel, androidDevice, apiKey, apiUrl, appBinaryId, appFilePath, async, config, deviceLocale, downloadArtifacts, env, excludeFlows, excludeTags, googlePlay, ignoreShaCheck, includeTags, iOSVersion, iosDevice, jsonFile, maestroVersion, name, orientation, report, retry, workspaceFolder, runnerType, debug, moropoV1ApiKey, useBeta, maestroChromeOnboarding, androidNoSnapshot, disableAnimations, githubContext, } = yield (0, params_1.getParameters)();
+        const { additionalAppBinaryIds, additionalAppFiles, androidApiLevel, androidDevice, apiKey, apiUrl, appBinaryId, appFilePath, appUrl, async, config, deviceLocale, downloadArtifacts, env, excludeFlows, excludeTags, googlePlay, ignoreShaCheck, includeTags, iOSVersion, iosDevice, jsonFile, jsonFileName, json, maestroVersion, name, orientation, report, retry, workspaceFolder, runnerType, debug, quiet, moropoV1ApiKey, useBeta, maestroChromeOnboarding, androidNoSnapshot, disableAnimations, showCrosshairs, dryRun, userMetadata, allurePath, htmlPath, artifactsPath, githubContext, } = yield (0, params_1.getParameters)();
         const REMOVED_MAESTRO_VERSIONS = ['1.39.2', '1.39.7', '2.0.3'];
         if (maestroVersion && REMOVED_MAESTRO_VERSIONS.includes(maestroVersion)) {
             (0, core_1.setFailed)(`Maestro version ${maestroVersion} is no longer supported. ` +
@@ -31619,6 +31619,7 @@ const run = () => __awaiter(void 0, void 0, void 0, function* () {
             'api-url': apiUrl,
             'app-binary-id': appBinaryId,
             'app-file': appFilePath,
+            'app-url': appUrl,
             async,
             config,
             'device-locale': deviceLocale,
@@ -31637,12 +31638,20 @@ const run = () => __awaiter(void 0, void 0, void 0, function* () {
             report,
             retry,
             'runner-type': runnerType,
+            json,
             'json-file': jsonFile,
+            'json-file-name': jsonFileName,
             debug,
+            quiet,
             'moropo-v1-api-key': moropoV1ApiKey,
             'maestro-chrome-onboarding': maestroChromeOnboarding,
             'android-no-snapshot': androidNoSnapshot,
             'disable-animations': disableAnimations,
+            'show-crosshairs': showCrosshairs,
+            'dry-run': dryRun,
+            'allure-path': allurePath,
+            'html-path': htmlPath,
+            'artifacts-path': artifactsPath,
         };
         let paramsString = Object.keys(params).reduce((acc, key) => {
             if (!params[key])
@@ -31663,6 +31672,11 @@ const run = () => __awaiter(void 0, void 0, void 0, function* () {
                 paramsString += ` --env ${key}=${escapeShellValue(value)}`;
             });
         }
+        if (userMetadata && userMetadata.length > 0) {
+            userMetadata.forEach((pair) => {
+                paramsString += ` --metadata ${escapeShellValue(pair)}`;
+            });
+        }
         if (githubContext && githubContext.length > 0) {
             githubContext.forEach((pair) => {
                 paramsString += ` --metadata ${escapeShellValue(pair)}`;
@@ -31672,7 +31686,7 @@ const run = () => __awaiter(void 0, void 0, void 0, function* () {
         let uploadId = null;
         let testOutput = '';
         try {
-            const { output, exitCode } = yield executeCommand(`npx --yes "${dcdVersionString}" cloud ${paramsString} --quiet`);
+            const { output, exitCode } = yield executeCommand(`npx --yes "${dcdVersionString}" cloud ${paramsString}`);
             testOutput = output;
             if (exitCode === 1) {
                 throw new Error('DeviceCloud CLI failed to run - check your parameters or contact support');
@@ -31891,9 +31905,6 @@ function getParameters() {
         const orientation = parseOrientation(core.getInput('orientation', { required: false }));
         const ignoreShaCheck = core.getInput('ignore-sha-check', { required: false }) === 'true';
         const report = core.getInput('report', { required: false });
-        if (report && report !== 'junit' && report !== 'html') {
-            throw new Error('Report format must be either "junit" or "html"');
-        }
         const config = core.getInput('config', { required: false });
         const runnerType = core.getInput('runner-type', { required: false });
         const jsonFile = core.getInput('json-file', { required: false }) === 'true';
@@ -31907,6 +31918,16 @@ function getParameters() {
         const maestroChromeOnboarding = core.getInput('maestro-chrome-onboarding', { required: false }) === 'true';
         const androidNoSnapshot = core.getInput('android-no-snapshot', { required: false }) === 'true';
         const disableAnimations = core.getInput('disable-animations', { required: false }) === 'true';
+        const showCrosshairs = core.getInput('show-crosshairs', { required: false }) === 'true';
+        const dryRun = core.getInput('dry-run', { required: false }) === 'true';
+        const appUrl = core.getInput('app-url', { required: false }) || undefined;
+        const userMetadata = core.getMultilineInput('metadata', { required: false });
+        const json = core.getInput('json', { required: false }) === 'true';
+        const jsonFileName = core.getInput('json-file-name', { required: false }) || undefined;
+        const allurePath = core.getInput('allure-path', { required: false }) || undefined;
+        const htmlPath = core.getInput('html-path', { required: false }) || undefined;
+        const artifactsPath = core.getInput('artifacts-path', { required: false }) || undefined;
+        const quiet = core.getInput('quiet', { required: false }) !== 'false';
         if (!(appFilePath !== '') !== (appBinaryId !== '')) {
             throw new Error('Either app-file or app-binary-id must be used');
         }
@@ -31918,6 +31939,7 @@ function getParameters() {
             apiUrl,
             apiKey,
             appFilePath,
+            appUrl,
             workspaceFolder,
             env,
             async,
@@ -31943,12 +31965,21 @@ function getParameters() {
             config,
             runnerType,
             jsonFile,
+            jsonFileName,
+            json,
             debug,
+            quiet,
             moropoV1ApiKey,
             useBeta,
             maestroChromeOnboarding,
             androidNoSnapshot,
             disableAnimations,
+            showCrosshairs,
+            dryRun,
+            userMetadata,
+            allurePath,
+            htmlPath,
+            artifactsPath,
             githubContext,
         };
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,6 +130,7 @@ const run = async (): Promise<void> => {
       apiUrl,
       appBinaryId,
       appFilePath,
+      appUrl,
       async,
       config,
       deviceLocale,
@@ -143,6 +144,8 @@ const run = async (): Promise<void> => {
       iOSVersion,
       iosDevice,
       jsonFile,
+      jsonFileName,
+      json,
       maestroVersion,
       name,
       orientation,
@@ -151,11 +154,18 @@ const run = async (): Promise<void> => {
       workspaceFolder,
       runnerType,
       debug,
+      quiet,
       moropoV1ApiKey,
       useBeta,
       maestroChromeOnboarding,
       androidNoSnapshot,
       disableAnimations,
+      showCrosshairs,
+      dryRun,
+      userMetadata,
+      allurePath,
+      htmlPath,
+      artifactsPath,
       githubContext,
     } = await getParameters();
 
@@ -179,6 +189,7 @@ const run = async (): Promise<void> => {
       'api-url': apiUrl,
       'app-binary-id': appBinaryId,
       'app-file': appFilePath,
+      'app-url': appUrl,
       async,
       config,
       'device-locale': deviceLocale,
@@ -197,12 +208,20 @@ const run = async (): Promise<void> => {
       report,
       retry,
       'runner-type': runnerType,
+      json,
       'json-file': jsonFile,
+      'json-file-name': jsonFileName,
       debug,
+      quiet,
       'moropo-v1-api-key': moropoV1ApiKey,
       'maestro-chrome-onboarding': maestroChromeOnboarding,
       'android-no-snapshot': androidNoSnapshot,
       'disable-animations': disableAnimations,
+      'show-crosshairs': showCrosshairs,
+      'dry-run': dryRun,
+      'allure-path': allurePath,
+      'html-path': htmlPath,
+      'artifacts-path': artifactsPath,
     };
 
     let paramsString = Object.keys(params).reduce((acc, key) => {
@@ -226,6 +245,12 @@ const run = async (): Promise<void> => {
       });
     }
 
+    if (userMetadata && userMetadata.length > 0) {
+      userMetadata.forEach((pair) => {
+        paramsString += ` --metadata ${escapeShellValue(pair)}`;
+      });
+    }
+
     if (githubContext && githubContext.length > 0) {
       githubContext.forEach((pair) => {
         paramsString += ` --metadata ${escapeShellValue(pair)}`;
@@ -238,7 +263,7 @@ const run = async (): Promise<void> => {
 
     try {
       const { output, exitCode } = await executeCommand(
-        `npx --yes "${dcdVersionString}" cloud ${paramsString} --quiet`
+        `npx --yes "${dcdVersionString}" cloud ${paramsString}`
       );
       testOutput = output;
 

--- a/src/methods/params.ts
+++ b/src/methods/params.ts
@@ -5,6 +5,7 @@ export type Params = {
   apiKey: string;
   apiUrl: string;
   appFilePath: string;
+  appUrl?: string;
   workspaceFolder: string | null;
   env?: string[];
   async?: boolean;
@@ -26,16 +27,25 @@ export type Params = {
   orientation?: 0 | 90 | 180 | 270;
   retry?: number;
   ignoreShaCheck?: boolean;
-  report?: 'junit' | 'html';
+  report?: 'junit' | 'html' | 'html-detailed' | 'allure';
   config?: string;
   runnerType?: string;
   jsonFile?: boolean;
+  jsonFileName?: string;
+  json?: boolean;
   debug?: boolean;
+  quiet?: boolean;
   moropoV1ApiKey?: string;
   useBeta?: boolean;
   maestroChromeOnboarding?: boolean;
   androidNoSnapshot?: boolean;
   disableAnimations?: boolean;
+  showCrosshairs?: boolean;
+  dryRun?: boolean;
+  userMetadata?: string[];
+  allurePath?: string;
+  htmlPath?: string;
+  artifactsPath?: string;
   githubContext?: string[];
 };
 
@@ -196,10 +206,9 @@ export async function getParameters(): Promise<Params> {
   const report = core.getInput('report', { required: false }) as
     | 'junit'
     | 'html'
+    | 'html-detailed'
+    | 'allure'
     | undefined;
-  if (report && report !== 'junit' && report !== 'html') {
-    throw new Error('Report format must be either "junit" or "html"');
-  }
 
   const config = core.getInput('config', { required: false });
   const runnerType = core.getInput('runner-type', { required: false });
@@ -217,6 +226,16 @@ export async function getParameters(): Promise<Params> {
   const maestroChromeOnboarding = core.getInput('maestro-chrome-onboarding', { required: false }) === 'true';
   const androidNoSnapshot = core.getInput('android-no-snapshot', { required: false }) === 'true';
   const disableAnimations = core.getInput('disable-animations', { required: false }) === 'true';
+  const showCrosshairs = core.getInput('show-crosshairs', { required: false }) === 'true';
+  const dryRun = core.getInput('dry-run', { required: false }) === 'true';
+  const appUrl = core.getInput('app-url', { required: false }) || undefined;
+  const userMetadata = core.getMultilineInput('metadata', { required: false });
+  const json = core.getInput('json', { required: false }) === 'true';
+  const jsonFileName = core.getInput('json-file-name', { required: false }) || undefined;
+  const allurePath = core.getInput('allure-path', { required: false }) || undefined;
+  const htmlPath = core.getInput('html-path', { required: false }) || undefined;
+  const artifactsPath = core.getInput('artifacts-path', { required: false }) || undefined;
+  const quiet = core.getInput('quiet', { required: false }) !== 'false';
 
   if (!(appFilePath !== '') !== (appBinaryId !== '')) {
     throw new Error('Either app-file or app-binary-id must be used');
@@ -234,6 +253,7 @@ export async function getParameters(): Promise<Params> {
     apiUrl,
     apiKey,
     appFilePath,
+    appUrl,
     workspaceFolder,
     env,
     async,
@@ -259,12 +279,21 @@ export async function getParameters(): Promise<Params> {
     config,
     runnerType,
     jsonFile,
+    jsonFileName,
+    json,
     debug,
+    quiet,
     moropoV1ApiKey,
     useBeta,
     maestroChromeOnboarding,
     androidNoSnapshot,
     disableAnimations,
+    showCrosshairs,
+    dryRun,
+    userMetadata,
+    allurePath,
+    htmlPath,
+    artifactsPath,
     githubContext,
   };
 }


### PR DESCRIPTION
Adds 9 inputs missing from the action (app-url, show-crosshairs, dry-run, metadata, json, json-file-name, allure-path, html-path, artifacts-path), fixes report to support allure/html-detailed, and makes quiet respect the input value instead of being hardcoded on.