### PR TITLE
feat: forward CI identity to the CLI for DB-driven notices

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2216,7 +2216,7 @@ const Context = __importStar(__nccwpck_require__(8663));
 const Utils = __importStar(__nccwpck_require__(1365));
 // octokit + plugins
 const core_1 = __nccwpck_require__(6895);
-const plugin_rest_endpoint_methods_1 = __nccwpck_require__(9289);
+const plugin_rest_endpoint_methods_1 = __nccwpck_require__(6495);
 const plugin_paginate_rest_1 = __nccwpck_require__(6212);
 exports.context = new Context.Context();
 const baseUrl = Utils.getApiBaseUrl();
@@ -40711,6 +40711,16 @@ const run = () => __awaiter(void 0, void 0, void 0, function* () {
                 paramsString += ` --metadata ${escapeShellValue(pair)}`;
             });
         }
+        // Forward CI identity so DCD notices can target this GitHub Action (e.g.
+        // "GitHub Action < X"). The CLI reads these env vars; the spawned child
+        // inherits process.env. Provider alone still enables CI-surface notices.
+        process.env.DCD_CI_PROVIDER = 'github';
+        try {
+            process.env.DCD_CI_WRAPPER_VERSION = (__nccwpck_require__(8330)/* .version */ .rE);
+        }
+        catch (_b) {
+            // best-effort — version is optional
+        }
         // Execute the test command and capture the upload ID
         let uploadId = null;
         let testOutput = '';
@@ -43153,7 +43163,7 @@ paginateRest.VERSION = VERSION;
 
 /***/ }),
 
-/***/ 9289:
+/***/ 6495:
 /***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __nccwpck_require__) => {
 
 "use strict";
@@ -43166,12 +43176,12 @@ __nccwpck_require__.d(__webpack_exports__, {
   restEndpointMethods: () => (/* binding */ restEndpointMethods)
 });
 
-;// CONCATENATED MODULE: ./node_modules/.pnpm/@octokit+plugin-rest-endpoint-methods@17.0.0_@octokit+core@7.0.6/node_modules/@octokit/plugin-rest-endpoint-methods/dist-src/version.js
+;// CONCATENATED MODULE: ./node_modules/.pnpm/@octokit+plugin-rest-endpoi_88f1cfdccbcd12f9bd89a662a3d08bce/node_modules/@octokit/plugin-rest-endpoint-methods/dist-src/version.js
 const VERSION = "17.0.0";
 
 //# sourceMappingURL=version.js.map
 
-;// CONCATENATED MODULE: ./node_modules/.pnpm/@octokit+plugin-rest-endpoint-methods@17.0.0_@octokit+core@7.0.6/node_modules/@octokit/plugin-rest-endpoint-methods/dist-src/generated/endpoints.js
+;// CONCATENATED MODULE: ./node_modules/.pnpm/@octokit+plugin-rest-endpoi_88f1cfdccbcd12f9bd89a662a3d08bce/node_modules/@octokit/plugin-rest-endpoint-methods/dist-src/generated/endpoints.js
 const Endpoints = {
   actions: {
     addCustomLabelsToSelfHostedRunnerForOrg: [
@@ -45465,7 +45475,7 @@ var endpoints_default = Endpoints;
 
 //# sourceMappingURL=endpoints.js.map
 
-;// CONCATENATED MODULE: ./node_modules/.pnpm/@octokit+plugin-rest-endpoint-methods@17.0.0_@octokit+core@7.0.6/node_modules/@octokit/plugin-rest-endpoint-methods/dist-src/endpoints-to-methods.js
+;// CONCATENATED MODULE: ./node_modules/.pnpm/@octokit+plugin-rest-endpoi_88f1cfdccbcd12f9bd89a662a3d08bce/node_modules/@octokit/plugin-rest-endpoint-methods/dist-src/endpoints-to-methods.js
 
 const endpointMethodsMap = /* @__PURE__ */ new Map();
 for (const [scope, endpoints] of Object.entries(endpoints_default)) {
@@ -45591,7 +45601,7 @@ function decorate(octokit, scope, methodName, defaults, decorations) {
 
 //# sourceMappingURL=endpoints-to-methods.js.map
 
-;// CONCATENATED MODULE: ./node_modules/.pnpm/@octokit+plugin-rest-endpoint-methods@17.0.0_@octokit+core@7.0.6/node_modules/@octokit/plugin-rest-endpoint-methods/dist-src/index.js
+;// CONCATENATED MODULE: ./node_modules/.pnpm/@octokit+plugin-rest-endpoi_88f1cfdccbcd12f9bd89a662a3d08bce/node_modules/@octokit/plugin-rest-endpoint-methods/dist-src/index.js
 
 
 function restEndpointMethods(octokit) {
@@ -45612,6 +45622,14 @@ legacyRestEndpointMethods.VERSION = VERSION;
 
 //# sourceMappingURL=index.js.map
 
+
+/***/ }),
+
+/***/ 8330:
+/***/ ((module) => {
+
+"use strict";
+module.exports = {"rE":"2.1.2"};
 
 /***/ })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -228,6 +228,18 @@ const run = async (): Promise<void> => {
       });
     }
 
+    // Forward CI identity so DCD notices can target this GitHub Action (e.g.
+    // "GitHub Action < X"). The CLI reads these env vars; the spawned child
+    // inherits process.env. Provider alone still enables CI-surface notices.
+    process.env.DCD_CI_PROVIDER = 'github';
+    try {
+      process.env.DCD_CI_WRAPPER_VERSION = (
+        require('../package.json') as { version?: string }
+      ).version;
+    } catch {
+      // best-effort — version is optional
+    }
+
     // Execute the test command and capture the upload ID
     let uploadId: string | null = null;
     let testOutput = '';


### PR DESCRIPTION
Set DCD_CI_PROVIDER=github and DCD_CI_WRAPPER_VERSION before invoking the dcd CLI so notices can target this GitHub Action (e.g. by version). Rebuilt dist.