### PR TITLE
fix: bump postcss to patch Dependabot alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   },
   "pnpm": {
     "overrides": {
-      "undici": ">=7.28.0"
+      "undici": ">=7.28.0",
+      "postcss": ">=8.5.18"
     }
   },
   "packageManager": "pnpm@10.29.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   undici: '>=7.28.0'
+  postcss: '>=8.5.18'
 
 importers:
 
@@ -500,8 +501,8 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -528,8 +529,8 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   rolldown@1.0.3:
@@ -1092,7 +1093,7 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.16: {}
 
   node-domexception@1.0.0: {}
 
@@ -1110,9 +1111,9 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  postcss@8.5.15:
+  postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -1173,7 +1174,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.25
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
Closes Dependabot alert [#28](https://github.com/devicecloud-dev/device-cloud-for-maestro/security/dependabot/28) — *PostCSS: Path Traversal in Previous Source Map Auto-Loading (sourceMappingURL) leads to Arbitrary .map File Disclosure*.

## Change

Added a `postcss: ">=8.5.18"` pnpm override alongside the existing `undici` one. postcss resolves **8.5.15 → 8.5.25**.

An override is required because postcss is transitive — `vitest 4.1.8 → vite → postcss` — so bumping a direct dependency would not move it.

## Impact assessment

Low. postcss is a **dev-only** dependency here:

- It enters via vitest; `dist` is built by `ncc` from `src`, so the vulnerable code never ships in the action bundle.
- The traversal requires parsing attacker-controlled CSS, which this project does not do.

The bump closes the alert rather than fixing a live exposure.

## Verification

`pnpm test` — 12/12 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/devicecloud-dev/codesmith/device-cloud-for-maestro/pr/40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788339579&installation_model_id=425387&pr_number=40&repository=devicecloud-dev%2Fdevice-cloud-for-maestro&return_to=https%3A%2F%2Fgithub.com%2Fdevicecloud-dev%2Fdevice-cloud-for-maestro%2Fpull%2F40&signature=fcd478c3441bb9848719a667f55719d2c9a06d3cbca950579e5db66943beefe2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->