### PR TITLE
docs(action): list API level 37 in android-api-level options

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     description: 'The ID of the app binary previously uploaded to devicecloud.dev'
     required: false
   android-api-level:
-    description: '[Android only] Android API level to run your flow against <options: 29|30|31|32|33|34|35|36>'
+    description: '[Android only] Android API level to run your flow against <options: 29|30|31|32|33|34|35|36|37>'
     required: false
   android-device:
     description: '[Android only] Android device to run your flow against <options: pixel-6|pixel-6-pro|pixel-7|pixel-7-pro|generic-tablet>'


### PR DESCRIPTION
Description-only. The input is parsed with a plain numeric coercion and validated server-side, so there is no src change and dist needs no rebuild.

Do not merge ahead of the production rollout — main is the released action.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/devicecloud-dev/codesmith/device-cloud-for-maestro/pr/43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->